### PR TITLE
Add composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,7 @@
+{
+    "name": "mdi/svg",
+    "description": "Material Design Icons SVG",
+    "type": "library",
+    "license": "MIT",
+    "require": {}
+}


### PR DESCRIPTION
This PR adds a composer.json file, allowing us to require this library as a composer (PHP npm) package.

We'll have to publish this on [packagist.org](https://packagist.org) before being able to `composer require mdi/svg`.

There is literally 0 maintenance once the package is published: you can use [GitHub hooks](https://packagist.org/about#how-to-update-packages) to tell packagist when a new version is published.

@Templarian : I don't know if we can use the `mdi/` namespace. A [composer package published on packagist](https://packagist.org/explore/?query=mdi%2F) already uses it, but I don't know if that means that we cannot use it. We can try - if it does not work, we can still use a package name like `material-design/svg`.